### PR TITLE
fix: copy app and tests into correct subdirectories in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,9 @@ WORKDIR /app
 COPY ./package.json ./package-lock.json ./
 RUN npm install
 
-# Copy application and test files
-COPY ./app ./tests ./
+# Copy application and test files into their expected subdirectories
+COPY ./app ./app
+COPY ./tests ./tests
 
 # Start the application
 CMD ["npm", "start"]


### PR DESCRIPTION
## Problem

`COPY ./app ./tests ./` copies all files flat into `/app/`, but `package.json` start script is `node app/start.js`, which expects the app code at `/app/app/start.js`. This causes the container to fail on startup with:

```
Error: Cannot find module '/app/app/start.js'
```

The `docker-compose.yml` dev setup already uses `volumes: - ./app:/app/app` confirming the intended layout.

## Fix

Split into two explicit `COPY` statements:

```dockerfile
COPY ./app ./app
COPY ./tests ./tests
```

Refs: arquivo/pwa-technologies#1517